### PR TITLE
Shift tag citation syntax to user-specified

### DIFF
--- a/sources/G.650.1-201803.adoc
+++ b/sources/G.650.1-201803.adoc
@@ -3748,7 +3748,7 @@ The following details shall be presented:
 [[bibliography]]
 == Bibliography
 
-* [[[b-ITU-T_G.Sup.47,ITU-T G Suppl. 47]]], ITU-T G-series Recommendations – Supplement 47 (2012), _General aspects of optical fibres and cables_.
+* [[[b-ITU-T_G.Sup.47,(b-ITU-T G.Suppl.47)ITU-T G.Suppl.47]]], ITU-T G-series Recommendations – Supplement 47 (2012), _General aspects of optical fibres and cables_.
 
 * [[[b-IEC60793-1-20,IEC 60793-1-20]]], IEC 60793-1-20 (2014), _Optical fibres – Part 1-20: Measurement methods and test procedures – Fibre geometry._
 

--- a/sources/T-Editing-Guidelines-201602.adoc
+++ b/sources/T-Editing-Guidelines-201602.adoc
@@ -835,31 +835,31 @@ The sole reference to a normative reference listed in clause 2 should not be mad
 [[Bibliography]]
 == Bibliography
 
-* [[[b-ITU-T_A.1,b-ITU-T A.1]]], Recommendation ITU-T A.1 (2012), _Working methods for study groups of the ITU Telecommunication Standardization Sector_.
+* [[[b-ITU-T_A.1,(b-ITU-T A.1)ITU-T A.1]]], Recommendation ITU-T A.1 (2012), _Working methods for study groups of the ITU Telecommunication Standardization Sector_.
 
-* [[[b-ITU-T_A.2,b-ITU-T A.2]]], Recommendation ITU-T A.2 (2012), _Presentation of contributions to the ITU Telecommunication Standardization Sector_.
+* [[[b-ITU-T_A.2,(b-ITU-T A.2)ITU-T A.2]]], Recommendation ITU-T A.2 (2012), _Presentation of contributions to the ITU Telecommunication Standardization Sector_.
 
-* [[[b-ITU-T_A.4,b-ITU-T A.4]]], Recommendation ITU-T A.4 (2012), _Communication process between the ITU Telecommunication Standardization Sector and forums and consortia_.
+* [[[b-ITU-T_A.4,(b-ITU-T A.4)ITU-T A.4]]], Recommendation ITU-T A.4 (2012), _Communication process between the ITU Telecommunication Standardization Sector and forums and consortia_.
 
-* [[[b-ITU-T_A.6,b-ITU-T A.6]]], Recommendation ITU-T A.6 (2012), _Cooperation and exchange of information between the ITU Telecommunication Standardization Sector and national and regional standards development organizations_.
+* [[[b-ITU-T_A.6,(b-ITU-T A.6)ITU-T A.6]]], Recommendation ITU-T A.6 (2012), _Cooperation and exchange of information between the ITU Telecommunication Standardization Sector and national and regional standards development organizations_.
 
-* [[[b-ITU-T_A.8,b-ITU-T A.8]]], Recommendation ITU-T A.8 (2008), _Alternative approval process for new and revised ITU-T Recommendations_.
+* [[[b-ITU-T_A.8,(b-ITU-T A.8)ITU-T A.8]]], Recommendation ITU-T A.8 (2008), _Alternative approval process for new and revised ITU-T Recommendations_.
 
-* [[[b-ITU-T_A.13,b-ITU-T A.13]]], Recommendation ITU-T A.13 (2000), _Supplements to ITU‑T Recommendations_.
+* [[[b-ITU-T_A.13,(b-ITU-T A.13)ITU-T A.13]]], Recommendation ITU-T A.13 (2000), _Supplements to ITU‑T Recommendations_.
 
-* [[[b-ITU-T_G.108.2,b-ITU-T G.108.2]]], Recommendation ITU-T G.108.2 (2007), _Transmission planning aspects of echo cancellers_.
+* [[[b-ITU-T_G.108.2,(b-ITU-T G.108.2)ITU-T G.108.2]]], Recommendation ITU-T G.108.2 (2007), _Transmission planning aspects of echo cancellers_.
 
-* [[[b-ITU-T_G.709,b-ITU-T G.709]]], Recommendation ITU-T G.709/Y.1331 (2012), _Interfaces for the optical transport network_.
+* [[[b-ITU-T_G.709,(b-ITU-T G.709)ITU-T G.709]]], Recommendation ITU-T G.709/Y.1331 (2012), _Interfaces for the optical transport network_.
 
-* [[[b-ITU-T_K.35,b-ITU-T K.35]]], Recommendation ITU-T K.35 (1996), _Bonding configurations and earthing at remote electronic sites_.
+* [[[b-ITU-T_K.35,(b-ITU-T K.35)ITU-T K.35]]], Recommendation ITU-T K.35 (1996), _Bonding configurations and earthing at remote electronic sites_.
 
-* [[[b-ITU-T_Rap,b-ITU-T Rap]]], ITU-T, _Manual for Rapporteurs and Editors_, 12 February 2010. +
+* [[[b-ITU-T_Rap,(b-ITU-T Rap)ITU-T Rap]]], ITU-T, _Manual for Rapporteurs and Editors_, 12 February 2010. +
 http://www.itu.int/oth/T0A0F000006/en[http://www.itu.int/oth/T0A0F000006/en]
 
-* [[[b-ITU_style,b-ITU style]]], _ITU English language style guide_ (2015). +
+* [[[b-ITU_style,(b-ITU style)ITU style]]], _ITU English language style guide_ (2015). +
 http://www.itu.int/SG-CP/docs/styleguide.doc[http://www.itu.int/SG-CP/docs/styleguide.doc]
 
-* [[[b-ISO_704,b-ISO 704]]], ISO 704:2009, _Terminology work – Principles and methods_.
+* [[[b-ISO_704,(b-ISO 704)ISO 704]]], ISO 704:2009, _Terminology work – Principles and methods_.
 
 * [[[b-Essay,b-Essay]]] Essay Writing Center, _Definition Essay_. +
 http://essayinfo.com/essays/definition_essay.php[http://essayinfo.com/essays/definition_essay.php] (Referenced 1.02.2016)

--- a/sources/T-REC-H.782-201811-I.MSW-E.adoc
+++ b/sources/T-REC-H.782-201811-I.MSW-E.adoc
@@ -1001,19 +1001,19 @@ image::T-REC-H.782/image010.png[]
 [bibliography]
 == Bibliography
 
-* [[[h760, b-ITU-T H.760]]] Recommendation ITU-T H.760 (2009_),__Overview of multimedia application frameworks for IPTV services_.
+* [[[h760,(b-ITU-T H.760)ITU-T H.760]]] Recommendation ITU-T H.760 (2009_),__Overview of multimedia application frameworks for IPTV services_.
 
-* [[[x1255, b-ITU-T X.1255]]] Recommendation ITU-T X.1255 (2013), _Framework for discovery of identity management information_.
+* [[[x1255,(b-ITU-T X.1255)ITU-T X.1255]]] Recommendation ITU-T X.1255 (2013), _Framework for discovery of identity management information_.
 
-* [[[iso639, b-ISO 639-2]]] ISO 639-2:1998, _Codes for the representation of names of languages– Part 2: Alpha-3 code_.
+* [[[iso639,(b-ISO 639-2)ISO 639-2]]] ISO 639-2:1998, _Codes for the representation of names of languages– Part 2: Alpha-3 code_.
 
 * [[[playlog, b-POPAI playlog]]] _Digital Signage Network Playlog Standards_, Version 1.1, 23 August 2006. https://www.pdffiller.com/51014346-Standards-Digital-Signage-Playlog-V1o1-2006pdf-Digital-Signage-Network-Playlog-Standards-Popai[https://www.pdffiller.com/51014346-Standards-Digital-Signage-Playlog-V1o1-2006pdf-Digital-Signage-Network-Playlog-Standards-Popai]
 
-* [[[rfc2046, b-RFC 2046]]] IETF RFC 2046 (1996), _Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types_.
+* [[[rfc2046,(b-RFC 2046)RFC 2046]]] IETF RFC 2046 (1996), _Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types_.
 
-* [[[rfc5646, b-RFC 5646]]] IETF RFC 5646 (2009), _Tags for Identifying Languages_.
+* [[[rfc5646,(b-RFC 5646)RFC 5646]]] IETF RFC 5646 (2009), _Tags for Identifying Languages_.
 
-* [[[csstransitions, b-W3C CSS Transitions]]] W3C, _CSS_ _Transitions_. https://www.w3.org/TR/css3-transitions[https://www.w3.org/TR/css3-transitions] – [Last accessed 02 Oct. 2018].
+* [[[csstransitions,(b-W3C CSS Transitions)W3C CSS Transitions]]] W3C, _CSS_ _Transitions_. https://www.w3.org/TR/css3-transitions[https://www.w3.org/TR/css3-transitions] – [Last accessed 02 Oct. 2018].
 
-* [[[csstransforms, b-W3C CSS Transforms]]] W3C, _CSS_ _Transforms Module Level 1_. https://www.w3.org/TR/css-transforms-1/[https://www.w3.org/TR/css-transforms-1/] – [Last accessed 02 Oct. 2018].
+* [[[csstransforms,(b-W3C CSS Transforms)W3C CSS Transforms]]] W3C, _CSS_ _Transforms Module Level 1_. https://www.w3.org/TR/css-transforms-1/[https://www.w3.org/TR/css-transforms-1/] – [Last accessed 02 Oct. 2018].
 


### PR DESCRIPTION
From https://github.com/metanorma/mn-samples-itu/issues/59

Only files containing tags of the style [b-ITU xxx], [b-ISO xxx], [b-RFC xxx], etc, were modified. 
For example,
````
* [[[h760,(b-ITU-T H.760)ITU-T H.760]]] Recommendation ITU-T H.760 (2009_),__Overview of multimedia application frameworks for IPTV services_.
* [[[b-ISO_704,(b-ISO 704)ISO 704]]], ISO 704:2009, _Terminology work – Principles and methods_.
* [[[rfc2046,(b-RFC 2046)RFC 2046]]] IETF RFC 2046 (1996), _Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types_.
````

Thanks!
