### PR TITLE
G.191: minor change

### DIFF
--- a/sources/G.191.adoc
+++ b/sources/G.191.adoc
@@ -7,7 +7,7 @@
 :published-date: 2019-01
 :status: in-force
 :doctype: recommendation
-:keywords: DSP operators, filters, MNRU, open source, reverb, STL2019, G.711, G.722, G.726, G.728, sv56.
+:keywords: DSP operators, filters, MNRU, open source, reverb, STL2019, G.711, G.722, G.726, G.728, sv56
 :imagesdir: images
 :docfile: G.191.adoc
 :mn-document-class: itu


### PR DESCRIPTION
Extra dot after keywords was producing double dot, i.e. "DSP operators, filters, G.711, G.722, G.726, G.728, MNRU, open source, reverb, STL2019, sv56..". 