### PR TITLE
D-REC-D.19-201003-E: minor changes

### DIFF
--- a/sources/D-REC-D.19-201003-E.adoc
+++ b/sources/D-REC-D.19-201003-E.adoc
@@ -13,11 +13,13 @@
 :section-refsig: Clause
 :xrefstyle: short
 
+== {blank}
+
 ITU-D
 
-recognizing
+_recognizing_
 
-. that the following Recommendations resulting from the ITU-D study periods 1998-2002 and 2002 2006 have provided guidance on a number of issues concerning telecommunications/ICTs in rural and remote areas:
+. that the following Recommendations resulting from the ITU-D study periods 1998-2002 and 2002-2006 have provided guidance on a number of issues concerning telecommunications/ICTs in rural and remote areas:
 
 ** RECOMMENDATION ITU-D 6-1, Appropriate low-cost technology options for the provision of telecommunications in rural and remote areas, (January, 2002);
 
@@ -37,11 +39,13 @@ recognizing
 . that the Focus Group 7 addressed technological options, service potential and financing mechanisms for the provision of telecommunications/ICTs in rural and remote areas;
 
 
-noting
+_noting_
 
 . that Focus Group 7 on Rural Telecommunications has paid particular attention to the role of Micro-Finance Institutions (MFI) in promoting access to ICT services and application by supporting small entrepreneurs
 
-. the excellent results of the study period 2006-2010 which consolidate experiences world-wide on the successful provision of telecommunications/ICTs to rural and remote areas, based, inter alia, on information submitted to the case library and on e-Discussions on the issues identified by the Rapporteur Group;
+. the excellent results of the study period 2006-2010 which consolidate experiences world-wide on the successful provision of telecommunications/ICTs to rural and remote areas, based, inter alia, on information submitted to the case library and on e-Discussions on the issues identified by the Rapporteur Group; {blank}footnote:[The case library on Question 10-2/2 is available at
+http://www.itu.int/ITU-D/study_groups/SGP_2006-2010/events/Case_Library/index.asp.
+e-Discussion web page is available at http://www.itu.int/ituweblogs/ITU-D-SG2-Q10/]
 
 . that experiences all over the world, with emerging technologies deployed in rural and remote areas providing broadband, wired transmission media and wireless transmission media indicate rapid decrease of costs, increase of range and capacity, and that all these developments make connecting rural areas a feasible option;
 
@@ -65,7 +69,7 @@ noting
 
 
 
-considering
+_considering_
 
 . that the provision of telecommunications, ICT services and applications can make significant contribution to the quality of life of the population living rural and remote areas;
 
@@ -79,7 +83,7 @@ considering
 
 
 
-recommends
+_recommends_
 
 . that developing countries should include provision of telecommunications/ICTs in rural and remote areas in their national development plans;
 
@@ -102,6 +106,3 @@ recommends
 . that given that lack of energy supply is a major bottleneck in the provision of telecommunications/ICTs in rural and remote areas, renewable energy sources should be used whenever feasible taking into consideration the environmental problems; and
 
 . that partnership among governments, industry, local agencies and international organizations is desirable in the development of low cost ICT infrastructure, including renewable energy sources and terminals for the provision of telecommunications/ICTs in rural and remote areas and should be pursued.
-
-
-


### PR DESCRIPTION
Content of the file wasn't rendering in DOC due to the missing section indication "==" after the main document attributes.

Original document has a very different style in comparison to the other ITU-T recommendations which were converted here.