### PR TITLE
Add :subtitle: for ITU A.8

### DIFF
--- a/sources/T-REC-A.8-200810-I!!MSW-E.adoc
+++ b/sources/T-REC-A.8-200810-I!!MSW-E.adoc
@@ -6,6 +6,7 @@
 :status: published
 :doctype: recommendation
 :keywords:
+:subtitle: (2000; 2004; 2006; 2008)
 :imagesdir: images
 :docfile: T-REC-A.8-200810-I!!MSW-E.adoc
 :mn-document-class: itu


### PR DESCRIPTION
Added `:subtitle:` document attribute to be rendered in Word only on title repetition at the start of the body, as per https://github.com/metanorma/metanorma-itu/issues/134#issuecomment-633607387.